### PR TITLE
remove some LD_LIBRARY_PATH magic, and PATH hacking

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hecdss
-version = 0.1.16
+version = 0.1.17
 author = Hydrologic Engineering Center
 author_email =hec.dss@usace.army.mil
 description = Python wrapper for the HEC-DSS file database C library.

--- a/src/hecdss/__init__.py
+++ b/src/hecdss/__init__.py
@@ -1,18 +1,3 @@
-import os
-import sys
-import ctypes
-from pathlib import Path
-
-
-shared_lib_dir = Path(__file__).parent.joinpath("lib")
-
-if sys.platform == "linux" or sys.platform == "darwin":
-    try:
-        os.environ["LD_LIBRARY_PATH"] = str(shared_lib_dir) + os.pathsep + os.environ['LD_LIBRARY_PATH']
-    except KeyError:
-        os.environ["LD_LIBRARY_PATH"] = str(shared_lib_dir)
-else:
-    os.environ['PATH'] = f"{shared_lib_dir};{os.environ['PATH']}"
 
 from hecdss.catalog import Catalog
 from hecdss.hecdss import HecDss


### PR DESCRIPTION
I previously cleaned up code in native.py to find the shared library.  I don't think we need this LD_LIBRARY_PATH hacking.

code to find library is here :https://github.com/HydrologicEngineeringCenter/hec-dss-python/blob/main/src/hecdss/native.py#L17
