### PR TITLE
Added support for numpy arrays with NaN values in GriddedData.create

### DIFF
--- a/src/hecdss/gridded_data.py
+++ b/src/hecdss/gridded_data.py
@@ -2,6 +2,8 @@
 import numpy as np
 import math
 
+NULL_INT = -3.4028234663852886e+38
+
 class GriddedData:
     """container for gridded (Raster) data
 
@@ -87,7 +89,7 @@ class GriddedData:
         self.rangeLimitTable = [0] * bins
         self.numberEqualOrExceedingRangeLimit = [0] * bins
 
-        self.rangeLimitTable[0] = -3.4028234663852886e+38
+        self.rangeLimitTable[0] = NULL_INT
         self.rangeLimitTable[1] = minval
 
         step = range_ / bins
@@ -107,13 +109,15 @@ class GriddedData:
         self.numberOfCellsX = len(self.data[0])
         self.numberOfCellsY = len(self.data)
         n = np.size(self.data)
-        self.maxDataValue = np.max(self.data)
-        self.minDataValue = np.min(self.data)
-        bin_range = (int)(math.ceil(self.maxDataValue) - math.floor(self.minDataValue))
-        self.meanDataValue = np.mean(self.data)
+        self.maxDataValue = np.nanmax(self.data)
+        self.minDataValue = np.nanmin(self.data)
+        bin_range = int(math.ceil(self.maxDataValue) - math.floor(self.minDataValue))
+        self.meanDataValue = np.nanmean(self.data)
+        
+        self.data = np.nan_to_num(self.data, nan=NULL_INT)
         self.numberOfRanges = math.floor(1 + 3.322 * math.log10(n) + 1)
-        flatData = self.data.flatten()
-        self.range_limit_table(self.minDataValue, self.maxDataValue, bin_range, self.numberOfRanges, n, flatData)
+        flat_data = self.data.flatten()
+        self.range_limit_table(self.minDataValue, self.maxDataValue, bin_range, self.numberOfRanges, n, flat_data)
 
     @staticmethod
     def create(path=None,


### PR DESCRIPTION
This PR corrects an issue with `GriddedData.create` which caused it to crash when passing in a `numpy` array with `NaN` values.

Also wanted to discuss two options I could think of for fixing the second part of #70 before implementing anything.
- Option A: remove parameters (`numberOfCellsX`, `numberOfCellsY`, `maxDataValue`, `minDataValue`, `meanDataValue`, `numberOfRanges`, `rangeLimitTable`, and `numberEqualOrExceedingRangeLimit`) from the create method that are calculated and set within the `GriddedData` class. This seems most intuitive, but the downside of this is that it would be a breaking change
- Option B: add a boolean parameter with a default value to the create method which dictates whether the values passed in should be preferred to calculating those values.