### PR TITLE
Time pattern/get period

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hec-dss-python"
-version = "0.1.20"
+version = "0.1.21"
 description = "Python wrapper for the HEC-DSS file database C library."
 authors = ["Hydrologic Engineering Center"]
 license = "MIT"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hecdss
-version = 0.1.20
+version = 0.1.21
 author = Hydrologic Engineering Center
 author_email =hec.dss@usace.army.mil
 description = Python wrapper for the HEC-DSS file database C library.

--- a/src/hecdss/catalog.py
+++ b/src/hecdss/catalog.py
@@ -42,9 +42,10 @@ class Catalog:
             if path.is_time_series():
                 cleanPath = str(path.path_without_date())
                 self.recordTypeDict[cleanPath.lower()] = recordType
-                tsRecords = self.timeSeriesDictNoDates.setdefault(cleanPath.lower(),[])
-                t = datetime.strptime(path.D,"%d%b%Y")
-                tsRecords.append(t)
+                if(path.D != "TS-Pattern"):
+                    tsRecords = self.timeSeriesDictNoDates.setdefault(cleanPath.lower(), [])
+                    t = datetime.strptime(path.D,"%d%b%Y")
+                    tsRecords.append(t)
             elif recordType in [RecordType.PairedData, RecordType.Grid, RecordType.Text,
                                 RecordType.LocationInfo, RecordType.Array]:
                 self.recordTypeDict[str(path).lower()] = recordType

--- a/src/hecdss/native.py
+++ b/src/hecdss/native.py
@@ -675,6 +675,33 @@ class _Native:
 
         return result
 
+    def hec_dss_numberPeriods(
+            self,
+            intervalSeconds,
+            julianStart,
+            startSeconds,
+            julianEnd,
+            endSeconds,
+    ):
+        self.dll.hec_dss_numberPeriods.argtypes = [
+            c_int,  # intervalSeconds
+            c_int,  # julianStart
+            c_int,  # startSeconds
+            c_int,  # julianEnd
+            c_int,  # endSeconds
+        ]
+        self.dll.hec_dss_numberPeriods.restype = c_int
+
+        result = self.dll.hec_dss_numberPeriods(
+            intervalSeconds,
+            julianStart,
+            startSeconds,
+            julianEnd,
+            endSeconds,
+        )
+
+        return result
+
     def hec_dss_tsRetrieve(
             self,
             pathname: str,
@@ -688,8 +715,8 @@ class _Native:
             numberValuesRead,
             quality: List[int],
             qualityLength: int,
-            julianBaseDate: int,
-            timeGranularitySeconds: int,
+            julianBaseDate: List[int],
+            timeGranularitySeconds: List[int],
             units: List[str],
             unitsLength: int,
             dataType: List[str],

--- a/tests/test_regular_timeseries.py
+++ b/tests/test_regular_timeseries.py
@@ -186,8 +186,20 @@ class TestRegularTimeSeries(unittest.TestCase):
         assert (rts.interval == rts_modified.interval), f"irts.interval is not equal to irts_modified.interval." \
                                                         f" irts.interval is {rts.interval}, irts_modified.interval is {rts_modified.interval}"
 
-
-
+    def test_regular_timeseries_empty_blocks(self):
+        """ test reading time-series with discontinuous blocks"""
+        pathname = "//SSPM5/ELEV/01Nov1991/1Hour/DCP-REV/"
+        filename = self.test_files.create_test_file(".dss")
+        with HecDss(filename) as dss:
+            rts = RegularTimeSeries.create(range(10), start_date=datetime(1988, 1, 1, 8, 0, 0), interval="1Hour",
+                                           units="cfs", path=pathname)
+            dss.put(rts)
+            rts = RegularTimeSeries.create(range(10), start_date=datetime(2016, 10, 11, 7, 0, 0), interval="1Hour",
+                                           units="cfs", path=pathname)
+            dss.put(rts)
+            ts = dss.get(pathname)
+            expected_count = 252273
+            assert ts.get_length() == expected_count, f" expected {expected_count} values, found {ts.get_length()}"
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request fixes the bug referenced in issue #55 by calculateing number of periods to read from a dss file and ignores the Time Pattern d part allowing dss file with Time Pattern values to open the catalog, as discussed in issue #69.