### PR TITLE
Large Interval Error

### DIFF
--- a/src/hecdss/regular_timeseries.py
+++ b/src/hecdss/regular_timeseries.py
@@ -125,6 +125,9 @@ class RegularTimeSeries:
         """
         if len(self.times) > 1 and type(self.times[0]) == datetime:
             interval = self.times[1]-self.times[0]
+            total_seconds = interval.total_seconds()
+            if total_seconds > 86400:
+                return "empty"
             return int(interval.total_seconds())
         return "empty"
 


### PR DESCRIPTION
When dealing with large intervals fails to take into account inconsistient time i.e differnt amount of days in month and leap days. Ignore for now. Futherwork for mainting consistan interval required, or let DSS base code return innconsistency error. fixes #91