### PR TITLE
Use `pytest.ini_options.pythonpath` instead of modifying `sys.path` in test modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,3 +68,4 @@ build-backend = "setuptools.build_meta"
 log_cli = true
 log_cli_level = 'INFO'
 testpaths = ["tests"]
+pythonpath = "./src"

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -1,14 +1,11 @@
 """Pytest module."""
 
 import unittest
-import os
-import sys
-import numpy as np
 
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
+import numpy as np
 from file_manager import FileManager
-from hecdss import HecDss, ArrayContainer
+
+from hecdss import ArrayContainer, HecDss
 
 
 class TestArray(unittest.TestCase):

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,14 +1,11 @@
 """Pytest module."""
 
 import unittest
-import os
-import sys
-
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
-from file_manager import FileManager
-from hecdss import Catalog, HecDss
 from datetime import datetime
+
+from file_manager import FileManager
+
+from hecdss import Catalog, HecDss
 
 
 class TestBasics(unittest.TestCase):

--- a/tests/test_dss_type.py
+++ b/tests/test_dss_type.py
@@ -1,9 +1,5 @@
 import unittest
-import os
-import sys
 
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
 from hecdss.dss_type import DssType
 
 

--- a/tests/test_dsspath.py
+++ b/tests/test_dsspath.py
@@ -1,15 +1,10 @@
 """Pytest module."""
 
 import unittest
-import os
-import sys
 
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
-
+from hecdss import DssPath
 from hecdss.cwms_utility import CwmsUtility
 from hecdss.dss_type import DssType
-from hecdss import DssPath
 
 
 class TestDssPath(unittest.TestCase):

--- a/tests/test_gridded_data.py
+++ b/tests/test_gridded_data.py
@@ -1,15 +1,12 @@
 """Pytest module."""
 
 import unittest
-import sys
-import os
-import numpy as np
 
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
+import numpy as np
 from file_manager import FileManager
-from hecdss.gridded_data import GriddedData
+
 from hecdss import HecDss
+from hecdss.gridded_data import GriddedData
 
 
 class TestGriddedData(unittest.TestCase):

--- a/tests/test_irregular_timeseries.py
+++ b/tests/test_irregular_timeseries.py
@@ -1,18 +1,16 @@
 """Pytest module."""
 
-import unittest
-import sys
 import os
-import numpy as np
-
-
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
-
-from file_manager import FileManager
-from hecdss.irregular_timeseries import IrregularTimeSeries
+import sys
+import unittest
 from datetime import datetime, timedelta
+
+import numpy as np
+from file_manager import FileManager
+
 from hecdss import HecDss
+from hecdss.irregular_timeseries import IrregularTimeSeries
+
 
 class TestRegularTimeSeries(unittest.TestCase):
 

--- a/tests/test_location_info.py
+++ b/tests/test_location_info.py
@@ -1,18 +1,11 @@
 """Pytest module."""
 
 import unittest
-import sys
-import os
-import numpy as np
-
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
 
 from file_manager import FileManager
-import copy
-from hecdss.paired_data import PairedData
-from hecdss.location_info import LocationInfo
+
 from hecdss import HecDss
+from hecdss.location_info import LocationInfo
 
 
 # update MODIFIED_TEST_DIR to be the path the folder containing dss files

--- a/tests/test_paired_data.py
+++ b/tests/test_paired_data.py
@@ -1,17 +1,13 @@
 """Pytest module."""
 
-import unittest
-import sys
-import os
-import numpy as np
-
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
-
-from file_manager import FileManager
 import copy
-from hecdss.paired_data import PairedData
+import unittest
+
+import numpy as np
+from file_manager import FileManager
+
 from hecdss import HecDss
+from hecdss.paired_data import PairedData
 
 
 # update MODIFIED_TEST_DIR to be the path the folder containing dss files

--- a/tests/test_regular_timeseries.py
+++ b/tests/test_regular_timeseries.py
@@ -1,19 +1,14 @@
 """Pytest module."""
 
 import unittest
-import sys
-import os
+from datetime import datetime, timedelta
 
 import numpy as np
+from file_manager import FileManager
 
 from hecdss import HecDss
-
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
-
-from file_manager import FileManager
 from hecdss.regular_timeseries import RegularTimeSeries
-from datetime import datetime, timedelta
+
 
 class TestRegularTimeSeries(unittest.TestCase):
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -1,16 +1,11 @@
 """Pytest module."""
 
 import unittest
-import sys
-import os
-
-from hecdss.record_type import RecordType
-
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
 
 from file_manager import FileManager
-from hecdss import Catalog, HecDss
+
+from hecdss import HecDss
+from hecdss.record_type import RecordType
 
 
 class TestText(unittest.TestCase):

--- a/tests/workshop.py
+++ b/tests/workshop.py
@@ -1,14 +1,9 @@
-
 """Pytest module."""
 
-import sys
-import os
-sys.path.append(r'src')
-sys.path.append(os.path.dirname(__file__))
-
+import copy
 
 from file_manager import FileManager
-import copy
+
 from hecdss import HecDss
 
 


### PR DESCRIPTION
# Description
This PR modifies `pyproject.toml` and sets a `pytest` setting to automatically add `.\src` to the PYTHONPATH. This alleviates the need to modify `sys.path` when writing test modules.

Tests are passing 100% on my Windows 11 machine, in a Python 3.12 environment. Not sure if there is a larger testing matrix that should be run.

# Code Changes

## Before

`pyproject.toml`
```toml
[tool.pytest.ini_options]
log_cli = true
log_cli_level = 'INFO'
testpaths = ["tests"]
```

`test_basics.py`
```python 
"""Pytest module."""

import unittest
import os
import sys

sys.path.append(r'src')
sys.path.append(os.path.dirname(__file__))
from file_manager import FileManager
from hecdss import Catalog, HecDss
from datetime import datetime

...
```

## After

`pyproject.toml`
```toml
[tool.pytest.ini_options]
log_cli = true
log_cli_level = 'INFO'
testpaths = ["tests"]
pythonpath = "./src"
```

`test_basics.py`
```python
"""Pytest module."""

import unittest
from datetime import datetime

from file_manager import FileManager

from hecdss import Catalog, HecDss

...
```