### PR TITLE
Add notes on message levels to docstrings and Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -121,6 +121,21 @@ This library uses (`hecdss.dll` on Windows and `libhecdss.so` on Unix/Linux).  h
    ```
 
 
+## Message Levels
+
+Message levels can be set using `set_global_debug_level` or `set_debug_level`, for example:
+
+```python
+from hecdss import HecDss
+mlvl: int = 4
+HecDss.set_global_debug_level(mlvl)
+```
+
+Common levels are described in the documentation for the `mlvl` parameter of the `zset` utility function from the [HEC-DSS Programmers Guide for C](https://www.hec.usace.army.mil/confluence/dssdocs/dsscprogrammer)
+
+Additional levels are described in the heclib source code C headers in [zdssMessages.h](https://github.com/HydrologicEngineeringCenter/hec-dss/blob/master/heclib/heclib_c/src/headers/zdssMessages.h)
+
+
 ## how to generate documentation
 
 pdoc -o docs -d google --no-show-source .\src

--- a/src/hecdss/hecdss.py
+++ b/src/hecdss/hecdss.py
@@ -61,7 +61,9 @@ class HecDss:
         Sets the library debug level
 
         Args:
-            level (int): a value between 0 and 15. Larger for more output
+            level (int): a value between 0 and 15. Larger for more output.
+                For level descriptions, see zdssMessages.h of the heclib source code,
+                or documentation from the HEC-DSS Programmers Guide for C on the `mlvl` parameter of the `zset` utility function.
         """
         _Native().hec_dss_set_debug_level(level)
     def close(self):
@@ -743,7 +745,9 @@ class HecDss:
         """sets the DSS debug level.
 
         Args:
-            level (int): a value between 0 and 15. Larger for more output
+            level (int): a value between 0 and 15. Larger for more output.
+                For level descriptions, see zdssMessages.h of the heclib source code,
+                or documentation from the HEC-DSS Programmers Guide for C on the `mlvl` parameter of the `zset` utility function.
 
         Returns:
             int: _description_

--- a/src/hecdss/native.py
+++ b/src/hecdss/native.py
@@ -90,6 +90,8 @@ class _Native:
     # set debug level (0-15)
     # 0 - no output
     # 15 - max output
+    # for additional levels: see zdssMessages.h of the heclib source code,
+    # or documentation from the HEC-DSS Programmers Guide for C on `mlvl` parameter of the `zset` utility function.
     def hec_dss_set_debug_level(self, value: int):
         self.__hec_dss_set_value("mlvl", value)
 


### PR DESCRIPTION
This PR adds brief notes on setting the message level, and references to descriptions of those levels.  `Readme.md` as well as some docstrings and comments in the Python code are updated.

Resolves #100