### PR TITLE
Catch when bad time zone is found and proceed with out any zone infor…

### DIFF
--- a/src/hecdss/hecdss.py
+++ b/src/hecdss/hecdss.py
@@ -1,6 +1,6 @@
 """Docstring for public module."""
 from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import numpy as np
 
@@ -474,7 +474,12 @@ class HecDss:
         julian_base_date = julianBaseDate[0]
         timeZoneName = timeZoneName[0]
         if(timeZoneName):
-            new_times = [i.replace(tzinfo=ZoneInfo(timeZoneName)) for i in new_times]
+            try:
+                new_times = [i.replace(tzinfo=ZoneInfo(timeZoneName)) for i in new_times]
+            except ZoneInfoNotFoundError as e: 
+                print(f"Warning: The timezone '{timeZoneName}' was not found. Using no zone instead.")
+                print(e)
+                timeZoneName = False
         elif (DssPath(pathname).D.lower() == "ts-pattern"):
             new_times = []
             start_date = _startDateTime - timedelta(seconds=interval_seconds)

--- a/src/hecdss/hecdss.py
+++ b/src/hecdss/hecdss.py
@@ -477,8 +477,7 @@ class HecDss:
             try:
                 new_times = [i.replace(tzinfo=ZoneInfo(timeZoneName)) for i in new_times]
             except ZoneInfoNotFoundError as e: 
-                print(f"Warning: The timezone '{timeZoneName}' was not found. Using no zone instead.")
-                print(e)
+                print(f"Warning: {e}. Using no zone instead.")
                 timeZoneName = False
         elif (DssPath(pathname).D.lower() == "ts-pattern"):
             new_times = []


### PR DESCRIPTION
Found a case where the time zone id in DSS cannot be recognized by ZoneInfo. "GMT +00:00" is not a valid key.  

Suggested trapping this error and proceeding to return with out any time zone info.

<img width="570" height="595" alt="image" src="https://github.com/user-attachments/assets/16848e94-dc2d-4e61-9036-9764a1d47305" />
