### PR TITLE
fix: fix incorrect path for download script in Readme.md (#113)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -113,7 +113,7 @@ This library uses (`hecdss.dll` on Windows and `libhecdss.so` on Unix/Linux).  h
    1. One option is to download it from provided link [hecdss.dll](https://github.com/HydrologicEngineeringCenter/hec-dss-python/releases/download/v0.0.1-alpha/hecdss.dll)
    2. Second option is to run the following python script in the repository directory:
       ```
-      python src\hec-dss-python\download_hecdss.py
+      python src\hecdss\download_hecdss.py
       ```
 3. from the repo directory (hec-dss-python)
    ```


### PR DESCRIPTION
Fixes the incorrect path on line 116 of Readme.md as reported in issue #113